### PR TITLE
Feat options "from"

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Options:
   --progressbar / --no-progressbar
                                   Display a progressbar
   --type [Document|NamedEntity]   Type of indexed documents to download
+  --skip INTEGER                  Number of first results to skip in the response.
   --size INTEGER                  Size of the scroll request that powers the
                                   operation.
 

--- a/tarentula/cli.py
+++ b/tarentula/cli.py
@@ -121,6 +121,7 @@ def clean_tags_by_query(**options):
 @click.option('--source', help='A comma-separated list of field to include in the downloaded document from the index',
               default=None)
 @click.option('--from', '-f', 'from_', type=int, help='Passed to the search it will bypass the first n documents', default=0)
+@click.option('--size', help='Size of the scroll request that powers the operation.', default=1000)
 @click.option('--sort-by', help='Field to use to sort results', default='_id')
 @click.option('--order-by', help='Order to use to sort results', default='asc', 
                             type=click.Choice(['asc', 'desc']))

--- a/tarentula/cli.py
+++ b/tarentula/cli.py
@@ -120,7 +120,7 @@ def clean_tags_by_query(**options):
 @click.option('--scroll', help='Scroll duration', default=None)
 @click.option('--source', help='A comma-separated list of field to include in the downloaded document from the index',
               default=None)
-@click.option('--skip', type=int, help='Number of first results to skip in return.', default=0)
+@click.option('--skip', type=int, help='Number of first results to skip in the response.', default=0)
 @click.option('--sort-by', help='Field to use to sort results', default='_id')
 @click.option('--order-by', help='Order to use to sort results', default='asc', 
                             type=click.Choice(['asc', 'desc']))
@@ -161,7 +161,7 @@ def download(**options):
 @click.option('--type', help='Type of indexed documents to download', default='Document',
               type=click.Choice(['Document', 'NamedEntity'], case_sensitive=True))
 @click.option('--size', help='Size of the scroll request that powers the operation.', default=1000)
-@click.option('--skip', type=int, help='Number of first results to skip in return.', default=0)
+@click.option('--skip', type=int, help='Number of first results to skip in the response.', default=0)
 @click.option('--query-field/--no-query-field', help='Add the query to the export CSV', default=True)
 def export_by_query(**options):
     # Instantiate an ExportByQuery class with all the options

--- a/tarentula/cli.py
+++ b/tarentula/cli.py
@@ -193,7 +193,8 @@ def count(**options):
               default='http://elasticsearch:9200')
 @click.option('--type', help='Type of indexed documents to get metadata', default='Document',
               type=click.Choice(['Document', 'NamedEntity'], case_sensitive=True))
-@click.option('--query_filter', help='Filter documents with field name and value separated by =', default='')
+@click.option('--filter_by', help='Filter documents by pairs concatenated by coma of field names and values separated by =.'
+                                  'Example "contentType=message/rfc822,contentType=message/rfc822"', default='')
 def list_metadata(**options):
     metadata = MetadataFields(**options)
     metadata.start()

--- a/tarentula/cli.py
+++ b/tarentula/cli.py
@@ -193,6 +193,7 @@ def count(**options):
               default='http://elasticsearch:9200')
 @click.option('--type', help='Type of indexed documents to get metadata', default='Document',
               type=click.Choice(['Document', 'NamedEntity'], case_sensitive=True))
+@click.option('--query_filter', help='Filter documents with field name and value separated by =', default='')
 def list_metadata(**options):
     metadata = MetadataFields(**options)
     metadata.start()

--- a/tarentula/cli.py
+++ b/tarentula/cli.py
@@ -120,7 +120,7 @@ def clean_tags_by_query(**options):
 @click.option('--scroll', help='Scroll duration', default=None)
 @click.option('--source', help='A comma-separated list of field to include in the downloaded document from the index',
               default=None)
-@click.option('--skip', type=int, help='Number of first results to skip in the response.', default=0)
+@click.option('--from', '-f', 'from_', type=int, help='Passed to the search it will bypass the first n documents', default=0)
 @click.option('--sort-by', help='Field to use to sort results', default='_id')
 @click.option('--order-by', help='Order to use to sort results', default='asc', 
                             type=click.Choice(['asc', 'desc']))
@@ -161,7 +161,7 @@ def download(**options):
 @click.option('--type', help='Type of indexed documents to download', default='Document',
               type=click.Choice(['Document', 'NamedEntity'], case_sensitive=True))
 @click.option('--size', help='Size of the scroll request that powers the operation.', default=1000)
-@click.option('--skip', type=int, help='Number of first results to skip in the response.', default=0)
+@click.option('--from', '-f', 'from_', type=int, help='Passed to the search it will bypass the first n documents', default=0)
 @click.option('--query-field/--no-query-field', help='Add the query to the export CSV', default=True)
 def export_by_query(**options):
     # Instantiate an ExportByQuery class with all the options

--- a/tarentula/cli.py
+++ b/tarentula/cli.py
@@ -160,6 +160,7 @@ def download(**options):
 @click.option('--type', help='Type of indexed documents to download', default='Document',
               type=click.Choice(['Document', 'NamedEntity'], case_sensitive=True))
 @click.option('--size', help='Size of the scroll request that powers the operation.', default=1000)
+@click.option('--skip', type=int, help='Number of first results to skip in return.', default=0)
 @click.option('--query-field/--no-query-field', help='Add the query to the export CSV', default=True)
 def export_by_query(**options):
     # Instantiate an ExportByQuery class with all the options

--- a/tarentula/cli.py
+++ b/tarentula/cli.py
@@ -120,6 +120,7 @@ def clean_tags_by_query(**options):
 @click.option('--scroll', help='Scroll duration', default=None)
 @click.option('--source', help='A comma-separated list of field to include in the downloaded document from the index',
               default=None)
+@click.option('--skip', type=int, help='Number of first results to skip in return.', default=0)
 @click.option('--sort-by', help='Field to use to sort results', default='_id')
 @click.option('--order-by', help='Order to use to sort results', default='asc', 
                             type=click.Choice(['asc', 'desc']))

--- a/tarentula/datashare_client.py
+++ b/tarentula/datashare_client.py
@@ -156,7 +156,7 @@ class DatashareClient:
             for item in response['hits']['hits']:
                 yield item
             search_after = response['hits']['hits'][-1]['sort']
-            search_after_args = {k: v for k, v in kwargs.items() if k is not 'from'}
+            search_after_args = {k: v for k, v in kwargs.items() if k != 'from'}
             response = self.query(search_after=search_after, **search_after_args)
 
     def count(self, index=DATASHARE_DEFAULT_PROJECT, query=None):

--- a/tarentula/datashare_client.py
+++ b/tarentula/datashare_client.py
@@ -120,6 +120,8 @@ class DatashareClient:
         return dest if result.status_code == requests.codes.ok else None
 
     def query(self, index=DATASHARE_DEFAULT_PROJECT, query={}, q=None, source=None, scroll=None, **kwargs):
+        if "skip" in kwargs.keys():
+            kwargs["from"] = kwargs.pop("skip")
         local_query = {"sort": {"_id": "asc"}, **query, **kwargs}
         if source is not None:
             local_query.update({'_source': source})

--- a/tarentula/datashare_client.py
+++ b/tarentula/datashare_client.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from http.cookies import SimpleCookie
 from uuid import uuid4
 
+from tarentula.logger import logger
+
 
 def urljoin(*args):
     return '/'.join(s.strip('/') for s in args if s is not None)
@@ -196,3 +198,16 @@ class DatashareClient:
                 self.delete_index(project)
         return project
 
+    def scan_or_query_all(self, datashare_project, source_fields_names, sort_by, order_by, scroll, query_body, from_, size):
+        index = datashare_project
+        source = source_fields_names
+        sort = {sort_by: order_by}
+        if scroll is None:
+            logger.info('Searching document(s) metadata in %s' % index)
+            return self.query_all(
+                **{'index': index, 'query': query_body, 'source': source, 'sort': sort, 'from': from_, 'size': size})
+        else:
+            logger.info('Scrolling over document(s) metadata in %s' % index)
+            if from_ > 0:
+                logger.warning('"from" will not be used when scrolling documents')
+            return self.scan_all(index=index, query=query_body, source=source, scroll=scroll, size=size, skip=from_, sort=sort)

--- a/tarentula/datashare_client.py
+++ b/tarentula/datashare_client.py
@@ -120,8 +120,6 @@ class DatashareClient:
         return dest if result.status_code == requests.codes.ok else None
 
     def query(self, index=DATASHARE_DEFAULT_PROJECT, query={}, q=None, source=None, scroll=None, **kwargs):
-        if "skip" in kwargs.keys():
-            kwargs["from"] = kwargs.pop("skip")
         local_query = {"sort": {"_id": "asc"}, **query, **kwargs}
         if source is not None:
             local_query.update({'_source': source})
@@ -158,7 +156,8 @@ class DatashareClient:
             for item in response['hits']['hits']:
                 yield item
             search_after = response['hits']['hits'][-1]['sort']
-            response = self.query(search_after=search_after, **kwargs)
+            search_after_args = {k: v for k, v in kwargs.items() if k is not 'from'}
+            response = self.query(search_after=search_after, **search_after_args)
 
     def count(self, index=DATASHARE_DEFAULT_PROJECT, query=None):
         if query is None: query = {}

--- a/tarentula/datashare_client.py
+++ b/tarentula/datashare_client.py
@@ -160,8 +160,9 @@ class DatashareClient:
             search_after = response['hits']['hits'][-1]['sort']
             response = self.query(search_after=search_after, **kwargs)
 
-    def count(self, index=DATASHARE_DEFAULT_PROJECT, query=None):
+    def count(self, index=DATASHARE_DEFAULT_PROJECT, skip=0, query=None):
         if query is None: query = {}
+        if skip > 0: query["from"] = skip
         url = urljoin(self.elasticsearch_host, index, '_count')
         return requests.post(url, json=query,
                              cookies=self.cookies,

--- a/tarentula/datashare_client.py
+++ b/tarentula/datashare_client.py
@@ -160,9 +160,8 @@ class DatashareClient:
             search_after = response['hits']['hits'][-1]['sort']
             response = self.query(search_after=search_after, **kwargs)
 
-    def count(self, index=DATASHARE_DEFAULT_PROJECT, skip=0, query=None):
+    def count(self, index=DATASHARE_DEFAULT_PROJECT, query=None):
         if query is None: query = {}
-        if skip > 0: query["from"] = skip
         url = urljoin(self.elasticsearch_host, index, '_count')
         return requests.post(url, json=query,
                              cookies=self.cookies,

--- a/tarentula/download.py
+++ b/tarentula/download.py
@@ -185,9 +185,6 @@ class Download:
 
     def start(self):
         count = self.log_matches()
-        count -= self.skip
-        count = self.size if self.size and self.size < count else count
-
         desc = "Downloading %s document(s)" % count
         try:
             with Progress(disable=self.no_progressbar) as progress:  

--- a/tarentula/download.py
+++ b/tarentula/download.py
@@ -24,7 +24,7 @@ class Download:
                  path_format: str = '{id_2b}/{id_4b}/{id}',
                  scroll: str = None,
                  source: str = None,
-                 skip: int = 0,
+                 from_: int = 0,
                  sort_by: str = '_id',
                  order_by: str = 'asc',
                  once: bool = False,
@@ -46,7 +46,7 @@ class Download:
         self.raw_file = raw_file
         self.source = source
         self.scroll = scroll
-        self.skip = skip
+        self.from_ = from_
         self.sort_by = sort_by
         self.order_by = order_by
         self.type = type
@@ -130,7 +130,7 @@ class Download:
 
     def count_matches(self):
         index = self.datashare_project
-        return self.datashare_client.count(index=index, query=self.query_body).get('count') - self.skip
+        return self.datashare_client.count(index=index, query=self.query_body).get('count') - self.from_
 
     def log_matches(self):
         index = self.datashare_project
@@ -144,11 +144,11 @@ class Download:
         sort = {self.sort_by: self.order_by}
         if self.scroll is None:
             logger.info('Searching document(s) metadata in %s' % index)
-            return self.datashare_client.query_all(**{'index': index, 'query': self.query_body, 'source': source, 'sort': sort, 'from': self.skip})
+            return self.datashare_client.query_all(**{'index': index, 'query': self.query_body, 'source': source, 'sort': sort, 'from': self.from_})
         else:
             logger.info('Scrolling over document(s) metadata in %s' % index)
-            if self.skip > 0:
-                logger.warning('skip will not be used when scrolling documents')
+            if self.from_ > 0:
+                logger.warning('"from" will not be used when scrolling documents')
             return self.datashare_client.scan_all(index=index, query=self.query_body, source=source, scroll=self.scroll, sort=sort)
 
     def download_raw_file(self, document):

--- a/tarentula/download.py
+++ b/tarentula/download.py
@@ -70,7 +70,6 @@ class Download:
     @property
     def query_body_from_string(self):
         return {
-            # "from": self.skip,
             "query": {
                 "bool": {
                     "must": [
@@ -93,8 +92,6 @@ class Download:
     def query_body_from_file(self):
         with open(self.query[1:]) as json_file:
             query_body = json.load(json_file)
-        # if self.skip and self.skip > 0:
-        #     query_body["from"] = self.skip
         return query_body
 
     @property
@@ -133,8 +130,7 @@ class Download:
 
     def count_matches(self):
         index = self.datashare_project
-        # return self.datashare_client.count(index=index, query=self.query_body).get('count')
-        return self.datashare_client.count(index=index, query=self.query_body).get('count') - self.skip
+        return self.datashare_client.count(index=index, query=self.query_body).get('count')
 
     def log_matches(self):
         index = self.datashare_project
@@ -187,6 +183,9 @@ class Download:
 
     def start(self):
         count = self.log_matches()
+        count -= self.skip
+        count = self.size if self.size and self.size < count else count
+
         desc = "Downloading %s document(s)" % count
         try:
             with Progress(disable=self.no_progressbar) as progress:  

--- a/tarentula/export_by_query.py
+++ b/tarentula/export_by_query.py
@@ -25,7 +25,7 @@ class ExportByQuery:
                  scroll: str = None,
                  source: str = 'contentType,contentLength:0,extractionDate,path',
                  size: int = 1000,
-                 skip: int = 0,
+                 from_: int = 0,
                  sort_by: str = '_id',
                  order_by: str = 'asc',
                  traceback: bool = False,
@@ -44,7 +44,7 @@ class ExportByQuery:
         self.scroll = scroll
         self.source = source
         self.size = size
-        self.skip = skip
+        self.from_ = from_
         self.sort_by = sort_by
         self.order_by = order_by
         self.type = type
@@ -146,12 +146,12 @@ class ExportByQuery:
         if self.scroll is None:
             logger.info('Searching document(s) metadata in %s' % index)
             return self.datashare_client.query_all(
-                **{'index': index, 'query': self.query_body, 'source': source, 'sort': sort, 'from': self.skip, 'size': self.size})
+                **{'index': index, 'query': self.query_body, 'source': source, 'sort': sort, 'from': self.from_, 'size': self.size})
         else:
             logger.info('Scrolling over document(s) metadata in %s' % index)
-            if self.skip > 0:
-                logger.warning('skip will not be used when scrolling documents')
-            return self.datashare_client.scan_all(index=index, query=self.query_body, source=source, scroll=self.scroll, size=self.size, skip=self.skip, sort=sort)
+            if self.from_ > 0:
+                logger.warning('"from" will not be used when scrolling documents')
+            return self.datashare_client.scan_all(index=index, query=self.query_body, source=source, scroll=self.scroll, size=self.size, skip=self.from_, sort=sort)
 
     def document_default_values(self, document, number):
         index = self.datashare_project
@@ -188,7 +188,7 @@ class ExportByQuery:
 
     def start(self):
         count = self.log_matches()
-        count -= self.skip
+        count -= self.from_
         count = self.size if self.size and self.size < count else count
         
         desc = 'Exporting %s document(s)' % count

--- a/tarentula/export_by_query.py
+++ b/tarentula/export_by_query.py
@@ -142,12 +142,15 @@ class ExportByQuery:
     def scan_or_query_all(self):
         index = self.datashare_project
         source = self.source_fields_names
-        sort = { self.sort_by: self.order_by }
+        sort = {self.sort_by: self.order_by}
         if self.scroll is None:
             logger.info('Searching document(s) metadata in %s' % index)
-            return self.datashare_client.query_all(index=index, query=self.query_body, source=source, size=self.size, skip=self.skip, sort=sort)
+            return self.datashare_client.query_all(
+                **{'index': index, 'query': self.query_body, 'source': source, 'sort': sort, 'from': self.skip, 'size': self.size})
         else:
             logger.info('Scrolling over document(s) metadata in %s' % index)
+            if self.skip > 0:
+                logger.warning('skip will not be used when scrolling documents')
             return self.datashare_client.scan_all(index=index, query=self.query_body, source=source, scroll=self.scroll, size=self.size, skip=self.skip, sort=sort)
 
     def document_default_values(self, document, number):

--- a/tarentula/export_by_query.py
+++ b/tarentula/export_by_query.py
@@ -185,6 +185,9 @@ class ExportByQuery:
 
     def start(self):
         count = self.log_matches()
+        count -= self.skip
+        count = self.size if self.size and self.size < count else count
+        
         desc = 'Exporting %s document(s)' % count
         try:
             with Progress(disable=self.no_progressbar) as progress:  

--- a/tarentula/export_by_query.py
+++ b/tarentula/export_by_query.py
@@ -25,6 +25,7 @@ class ExportByQuery:
                  scroll: str = None,
                  source: str = 'contentType,contentLength:0,extractionDate,path',
                  size: int = 1000,
+                 skip: int = 0,
                  sort_by: str = '_id',
                  order_by: str = 'asc',
                  traceback: bool = False,
@@ -43,6 +44,7 @@ class ExportByQuery:
         self.scroll = scroll
         self.source = source
         self.size = size
+        self.skip = skip
         self.sort_by = sort_by
         self.order_by = order_by
         self.type = type
@@ -143,10 +145,10 @@ class ExportByQuery:
         sort = { self.sort_by: self.order_by }
         if self.scroll is None:
             logger.info('Searching document(s) metadata in %s' % index)
-            return self.datashare_client.query_all(index=index, query=self.query_body, source=source, size=self.size, sort=sort)
+            return self.datashare_client.query_all(index=index, query=self.query_body, source=source, size=self.size, skip=self.skip, sort=sort)
         else:
             logger.info('Scrolling over document(s) metadata in %s' % index)
-            return self.datashare_client.scan_all(index=index, query=self.query_body, source=source, scroll=self.scroll, size=self.size, sort=sort)
+            return self.datashare_client.scan_all(index=index, query=self.query_body, source=source, scroll=self.scroll, size=self.size, skip=self.skip, sort=sort)
 
     def document_default_values(self, document, number):
         index = self.datashare_project

--- a/tarentula/metadata_fields.py
+++ b/tarentula/metadata_fields.py
@@ -12,6 +12,7 @@ class MetadataFields:
                  type: str = 'Document'):
         self.elasticsearch_url = elasticsearch_url
         self.datashare_project = datashare_project
+        
         if query_filter and "=" in query_filter:
             k, v = [part.strip() for part in query_filter.split("=")]
             self.query_filters = [

--- a/tarentula/metadata_fields.py
+++ b/tarentula/metadata_fields.py
@@ -8,9 +8,18 @@ class MetadataFields:
     def __init__(self,
                  datashare_project: str = 'local-datashare',
                  elasticsearch_url: str = 'http://elasticsearch:9200',
+                 query_filter: str = '',
                  type: str = 'Document'):
         self.elasticsearch_url = elasticsearch_url
         self.datashare_project = datashare_project
+        if query_filter and "=" in query_filter:
+            k, v = [part.strip() for part in query_filter.split("=")]
+            self.query_filters = [
+                {"term": {f"{k}": f"{v}"}} 
+            ]
+        else:
+            self.query_filters = []
+
         self.type = type
 
     def query_mapping(self):
@@ -18,9 +27,20 @@ class MetadataFields:
         return requests.get(url).json()
 
     def query_count(self, complete_field_name):
+        query_filters = self.query_filters + [{"exists": {"field": complete_field_name}}]
         query={
-            "query": {"bool": {"must": {"match": {"type": self.type}},
-                                "filter": {"exists": {"field": complete_field_name}}}}
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "type": self.type
+                            }
+                        }
+                    ],
+                    "filter": query_filters
+                }
+            }
         }
         url = urljoin(self.elasticsearch_url, self.datashare_project, '_count')
         return requests.post(url, json=query).json()
@@ -44,7 +64,7 @@ class MetadataFields:
         return results
 
     def start(self):
-        mapping = self.query_mapping()        
+        mapping = self.query_mapping()
         
         fields = self.get_fields(mapping, [])
         print(dumps(fields))

--- a/tarentula/metadata_fields.py
+++ b/tarentula/metadata_fields.py
@@ -8,13 +8,13 @@ class MetadataFields:
     def __init__(self,
                  datashare_project: str = 'local-datashare',
                  elasticsearch_url: str = 'http://elasticsearch:9200',
-                 query_filter: str = '',
+                 filter_by: str = '',
                  type: str = 'Document'):
         self.elasticsearch_url = elasticsearch_url
         self.datashare_project = datashare_project
-        
-        if query_filter and "=" in query_filter:
-            k, v = [part.strip() for part in query_filter.split("=")]
+
+        if filter_by and "=" in filter_by:
+            k, v = [part.strip() for part in filter_by.split("=")]
             self.query_filters = [
                 {"term": {f"{k}": f"{v}"}} 
             ]

--- a/tarentula/metadata_fields.py
+++ b/tarentula/metadata_fields.py
@@ -14,9 +14,10 @@ class MetadataFields:
         self.datashare_project = datashare_project
 
         if filter_by and "=" in filter_by:
-            k, v = [part.strip() for part in filter_by.split("=")]
+            filters = filter_by.split(",")
+            filter_pairs = [map(str.strip, part.split("=")) for part in filters if "=" in part]
             self.query_filters = [
-                {"term": {f"{k}": f"{v}"}} 
+                {"term": {f"{k}": f"{v}"}} for k, v in filter_pairs
             ]
         else:
             self.query_filters = []

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -77,11 +77,11 @@ class TestDownload(TestAbstract):
             self.assertIn('_source', json)
             self.assertIn('name', json['_source'])
 
-    def test_summary_with_skip(self):
+    def test_summary_with_from(self):
         with self.existing_species_documents(), TemporaryDirectory() as tmp:
             runner = CliRunner()
             
-            result = runner.invoke(cli, ['download', '--datashare-url', self.datashare_url, '--elasticsearch-url', self.elasticsearch_url, '--datashare-project', self.datashare_project, '--no-raw-file', '--destination-directory', tmp, '--skip', 5, '--query', 'name:*'])
+            result = runner.invoke(cli, ['download', '--datashare-url', self.datashare_url, '--elasticsearch-url', self.elasticsearch_url, '--datashare-project', self.datashare_project, '--no-raw-file', '--destination-directory', tmp, '--from', 5, '--query', 'name:*'])
             self.assertIn('Downloading 15 document(s)', result.output)
             self.assertEqual(15, len(get_document_files(tmp)))
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -75,3 +75,10 @@ class TestDownload(TestAbstract):
             self.assertIn('_id', json)
             self.assertIn('_source', json)
             self.assertIn('name', json['_source'])
+
+    def test_summary_with_skip(self):
+        with self.existing_species_documents():
+            runner = CliRunner()
+            
+            result = runner.invoke(cli, ['download', '--datashare-url', self.datashare_url, '--elasticsearch-url', self.elasticsearch_url, '--datashare-project', self.datashare_project, '--no-raw-file', '--skip', 5, '--query', 'name:*'])
+            self.assertIn('Downloading 15 document(s)', result.output)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,3 +1,4 @@
+import glob
 import json
 from os.path import join
 from tempfile import TemporaryDirectory
@@ -76,9 +77,14 @@ class TestDownload(TestAbstract):
             self.assertIn('_source', json)
             self.assertIn('name', json['_source'])
 
-    def test_summary_with_skip_option(self):
-        with self.existing_species_documents():
+    def test_summary_with_skip(self):
+        with self.existing_species_documents(), TemporaryDirectory() as tmp:
             runner = CliRunner()
             
-            result = runner.invoke(cli, ['download', '--datashare-url', self.datashare_url, '--elasticsearch-url', self.elasticsearch_url, '--datashare-project', self.datashare_project, '--no-raw-file', '--skip', 5, '--query', 'name:*'])
+            result = runner.invoke(cli, ['download', '--datashare-url', self.datashare_url, '--elasticsearch-url', self.elasticsearch_url, '--datashare-project', self.datashare_project, '--no-raw-file', '--destination-directory', tmp, '--skip', 5, '--query', 'name:*'])
             self.assertIn('Downloading 15 document(s)', result.output)
+            self.assertEqual(15, len(get_document_files(tmp)))
+
+
+def get_document_files(folder: str, pattern: str = '*/*/*.json'):
+    return glob.glob(join(folder, pattern))

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -76,7 +76,7 @@ class TestDownload(TestAbstract):
             self.assertIn('_source', json)
             self.assertIn('name', json['_source'])
 
-    def test_summary_with_skip(self):
+    def test_summary_with_skip_option(self):
         with self.existing_species_documents():
             runner = CliRunner()
             

--- a/tests/test_export_by_query.py
+++ b/tests/test_export_by_query.py
@@ -51,14 +51,14 @@ class TestExportByQuery(TestAbstract):
                 self.assertIsInstance(datetime_object, datetime)
                 self.assertEqual(row['documentNumber'], '1')
 
-    def test_csv_file_with_skip(self):
+    def test_csv_file_with_from(self):
         with self.existing_species_documents(), TemporaryDirectory() as tmp:
             output_file = join(tmp, 'output.csv')
             runner = CliRunner()
             runner.invoke(cli, ['export-by-query', '--datashare-url', self.datashare_url, '--elasticsearch-url',
                                 self.elasticsearch_url, '--datashare-project', self.datashare_project, '--query',
                                 'Actinopodidae OR Antrodiaetidae', 
-                                '--skip', 1, '--output-file', output_file])
+                                '--from', 1, '--output-file', output_file])
             with open(output_file, newline='') as csv_file:
                 csv_reader = csv.DictReader(csv_file)
                 self.assertEqual(len(list(csv_reader)), 1) # total size is 2 documents

--- a/tests/test_export_by_query.py
+++ b/tests/test_export_by_query.py
@@ -51,32 +51,7 @@ class TestExportByQuery(TestAbstract):
                 self.assertIsInstance(datetime_object, datetime)
                 self.assertEqual(row['documentNumber'], '1')
 
-    def test_csv_file_option_size_1(self):
-        with self.existing_species_documents(), TemporaryDirectory() as tmp:
-            output_file = join(tmp, 'output.csv')
-            runner = CliRunner()
-            runner.invoke(cli, ['export-by-query', '--datashare-url', self.datashare_url, '--elasticsearch-url',
-                                self.elasticsearch_url, '--datashare-project', self.datashare_project, '--query',
-                                'Actinopodidae OR Antrodiaetidae', 
-                                '--size', 1, '--output-file', output_file])
-            with open(output_file, newline='') as csv_file:
-                csv_reader = csv.DictReader(csv_file)
-
-                # First row
-                row = next(csv_reader)
-                self.assertEqual(row['query'], 'Actinopodidae OR Antrodiaetidae')
-                self.assertEqual(row['documentUrl'],
-                                 'http://localhost:8080/#/d/test-datashare/DWLOskax28jPQ2CjFrCo/l7VnZZEzg2fr960NWWEG')
-                self.assertEqual(row['documentId'], 'DWLOskax28jPQ2CjFrCo')
-                self.assertEqual(row['rootId'], 'l7VnZZEzg2fr960NWWEG')
-                self.assertEqual(row['contentType'], 'audio/vnd.wave')
-                self.assertEqual(row['contentLength'], '0')
-                self.assertEqual(row['path'], '')
-                datetime_object = datetime.strptime(row['extractionDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
-                self.assertIsInstance(datetime_object, datetime)
-                self.assertEqual(row['documentNumber'], '0')
-
-    def test_csv_file_option_skip_1(self):
+    def test_csv_file_with_skip(self):
         with self.existing_species_documents(), TemporaryDirectory() as tmp:
             output_file = join(tmp, 'output.csv')
             runner = CliRunner()
@@ -86,17 +61,4 @@ class TestExportByQuery(TestAbstract):
                                 '--skip', 1, '--output-file', output_file])
             with open(output_file, newline='') as csv_file:
                 csv_reader = csv.DictReader(csv_file)
-
-                # Second row => First row
-                row = next(csv_reader)
-                self.assertEqual(row['query'], 'Actinopodidae OR Antrodiaetidae')
-                self.assertEqual(row['documentUrl'],
-                                 'http://localhost:8080/#/d/test-datashare/l7VnZZEzg2fr960NWWEG/l7VnZZEzg2fr960NWWEG')
-                self.assertEqual(row['documentId'], 'l7VnZZEzg2fr960NWWEG')
-                self.assertEqual(row['rootId'], 'l7VnZZEzg2fr960NWWEG')
-                self.assertEqual(row['contentType'], 'audio/mpeg')
-                self.assertEqual(row['contentLength'], '25')
-                self.assertEqual(row['path'], '/path/to/file.txt')
-                datetime_object = datetime.strptime(row['extractionDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
-                self.assertIsInstance(datetime_object, datetime)
-                self.assertEqual(row['documentNumber'], '0')
+                self.assertEqual(len(list(csv_reader)), 1) # total size is 2 documents

--- a/tests/test_export_by_query.py
+++ b/tests/test_export_by_query.py
@@ -50,3 +50,53 @@ class TestExportByQuery(TestAbstract):
                 datetime_object = datetime.strptime(row['extractionDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
                 self.assertIsInstance(datetime_object, datetime)
                 self.assertEqual(row['documentNumber'], '1')
+
+    def test_csv_file_limit_1(self):
+        with self.existing_species_documents(), TemporaryDirectory() as tmp:
+            output_file = join(tmp, 'output.csv')
+            runner = CliRunner()
+            runner.invoke(cli, ['export-by-query', '--datashare-url', self.datashare_url, '--elasticsearch-url',
+                                self.elasticsearch_url, '--datashare-project', self.datashare_project, '--query',
+                                'Actinopodidae OR Antrodiaetidae', 
+                                '--size', 1, '--output-file', output_file])
+            with open(output_file, newline='') as csv_file:
+                csv_reader = csv.DictReader(csv_file)
+
+                # First row
+                row = next(csv_reader)
+                self.assertEqual(row['query'], 'Actinopodidae OR Antrodiaetidae')
+                self.assertEqual(row['documentUrl'],
+                                 'http://localhost:8080/#/d/test-datashare/DWLOskax28jPQ2CjFrCo/l7VnZZEzg2fr960NWWEG')
+                self.assertEqual(row['documentId'], 'DWLOskax28jPQ2CjFrCo')
+                self.assertEqual(row['rootId'], 'l7VnZZEzg2fr960NWWEG')
+                self.assertEqual(row['contentType'], 'audio/vnd.wave')
+                self.assertEqual(row['contentLength'], '0')
+                self.assertEqual(row['path'], '')
+                datetime_object = datetime.strptime(row['extractionDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
+                self.assertIsInstance(datetime_object, datetime)
+                self.assertEqual(row['documentNumber'], '0')
+
+    def test_csv_file_skip_1(self):
+        with self.existing_species_documents(), TemporaryDirectory() as tmp:
+            output_file = join(tmp, 'output.csv')
+            runner = CliRunner()
+            runner.invoke(cli, ['export-by-query', '--datashare-url', self.datashare_url, '--elasticsearch-url',
+                                self.elasticsearch_url, '--datashare-project', self.datashare_project, '--query',
+                                'Actinopodidae OR Antrodiaetidae', 
+                                '--skip', 1, '--output-file', output_file])
+            with open(output_file, newline='') as csv_file:
+                csv_reader = csv.DictReader(csv_file)
+
+                # Second row => First row
+                row = next(csv_reader)
+                self.assertEqual(row['query'], 'Actinopodidae OR Antrodiaetidae')
+                self.assertEqual(row['documentUrl'],
+                                 'http://localhost:8080/#/d/test-datashare/l7VnZZEzg2fr960NWWEG/l7VnZZEzg2fr960NWWEG')
+                self.assertEqual(row['documentId'], 'l7VnZZEzg2fr960NWWEG')
+                self.assertEqual(row['rootId'], 'l7VnZZEzg2fr960NWWEG')
+                self.assertEqual(row['contentType'], 'audio/mpeg')
+                self.assertEqual(row['contentLength'], '25')
+                self.assertEqual(row['path'], '/path/to/file.txt')
+                datetime_object = datetime.strptime(row['extractionDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
+                self.assertIsInstance(datetime_object, datetime)
+                self.assertEqual(row['documentNumber'], '0')

--- a/tests/test_export_by_query.py
+++ b/tests/test_export_by_query.py
@@ -51,7 +51,7 @@ class TestExportByQuery(TestAbstract):
                 self.assertIsInstance(datetime_object, datetime)
                 self.assertEqual(row['documentNumber'], '1')
 
-    def test_csv_file_limit_1(self):
+    def test_csv_file_option_size_1(self):
         with self.existing_species_documents(), TemporaryDirectory() as tmp:
             output_file = join(tmp, 'output.csv')
             runner = CliRunner()
@@ -76,7 +76,7 @@ class TestExportByQuery(TestAbstract):
                 self.assertIsInstance(datetime_object, datetime)
                 self.assertEqual(row['documentNumber'], '0')
 
-    def test_csv_file_skip_1(self):
+    def test_csv_file_option_skip_1(self):
         with self.existing_species_documents(), TemporaryDirectory() as tmp:
             output_file = join(tmp, 'output.csv')
             runner = CliRunner()

--- a/tests/test_metadata_fields.py
+++ b/tests/test_metadata_fields.py
@@ -42,7 +42,7 @@ class TestMetadataFields(TestAbstract):
                           {'count': 1, 'field': 'name', 'type': 'text'},
                           {'count': 1, 'field': 'type', 'type': 'keyword'}], json_result)
 
-    def test_metadata_field_filter_1(self):
+    def test_metadata_field_filter_no_sum(self):
         self.index_documents([
             {"name": "Antrodiaetidae", "type": "Document", "contentType": "audio/vnd.wave", "_id": "id1"},
             {"name": "Antrodiaetidae", "type": "Document", "contentType": "message/rfc822", "subject": "hello world", "_id": "id2"}
@@ -58,3 +58,22 @@ class TestMetadataFields(TestAbstract):
                           {'count': 1, 'field': 'extractionDate', 'type': 'date'},
                           {'count': 1, 'field': 'name', 'type': 'text'},
                           {'count': 1, 'field': 'type', 'type': 'keyword'}], json_result)
+
+    def test_metadata_field_filter_sum(self):
+        self.index_documents([
+            {"name": "Antrodiaetidae", "type": "Document", "contentType": "audio/vnd.wave", "_id": "id1"},
+            {"name": "Antrodiaetidae", "type": "Document", "contentType": "message/rfc822", "subject": "Hello World", "_id": "id2"},
+            {"name": "Antrodiaetidae", "type": "Document", "contentType": "message/rfc822", "subject": "Bye Moon", "_id": "id3"}
+        ])
+        runner = CliRunner()
+        result = runner.invoke(cli, ['list-metadata', 
+                                    '--elasticsearch-url', self.elasticsearch_url, 
+                                    '--datashare-project', self.datashare_project,
+                                    '--query_filter', 'contentType=message/rfc822', 
+                                    ])
+        json_result = loads(result.output)
+        self.assertEqual([{'count': 2, 'field': 'contentType', 'type': 'keyword'},
+                          {'count': 2, 'field': 'extractionDate', 'type': 'date'},
+                          {'count': 2, 'field': 'name', 'type': 'text'},
+                          {'count': 2, 'field': 'subject', 'type': 'text'},
+                          {'count': 2, 'field': 'type', 'type': 'keyword'}], json_result)

--- a/tests/test_metadata_fields.py
+++ b/tests/test_metadata_fields.py
@@ -41,3 +41,20 @@ class TestMetadataFields(TestAbstract):
                            'type': 'date'},
                           {'count': 1, 'field': 'name', 'type': 'text'},
                           {'count': 1, 'field': 'type', 'type': 'keyword'}], json_result)
+
+    def test_metadata_field_filter_1(self):
+        self.index_documents([
+            {"name": "Antrodiaetidae", "type": "Document", "contentType": "audio/vnd.wave", "_id": "id1"},
+            {"name": "Antrodiaetidae", "type": "Document", "contentType": "message/rfc822", "subject": "hello world", "_id": "id2"}
+        ])
+        runner = CliRunner()
+        result = runner.invoke(cli, ['list-metadata', 
+                                    '--elasticsearch-url', self.elasticsearch_url, 
+                                    '--datashare-project', self.datashare_project,
+                                    '--query_filter', 'contentType=audio/vnd.wave', 
+                                    ])
+        json_result = loads(result.output)
+        self.assertEqual([{'count': 1, 'field': 'contentType', 'type': 'keyword'},
+                          {'count': 1, 'field': 'extractionDate', 'type': 'date'},
+                          {'count': 1, 'field': 'name', 'type': 'text'},
+                          {'count': 1, 'field': 'type', 'type': 'keyword'}], json_result)

--- a/tests/test_metadata_fields.py
+++ b/tests/test_metadata_fields.py
@@ -51,7 +51,7 @@ class TestMetadataFields(TestAbstract):
         result = runner.invoke(cli, ['list-metadata', 
                                     '--elasticsearch-url', self.elasticsearch_url, 
                                     '--datashare-project', self.datashare_project,
-                                    '--query_filter', 'contentType=audio/vnd.wave', 
+                                    '--filter_by', 'contentType=audio/vnd.wave', 
                                     ])
         json_result = loads(result.output)
         self.assertEqual([{'count': 1, 'field': 'contentType', 'type': 'keyword'},
@@ -69,7 +69,7 @@ class TestMetadataFields(TestAbstract):
         result = runner.invoke(cli, ['list-metadata', 
                                     '--elasticsearch-url', self.elasticsearch_url, 
                                     '--datashare-project', self.datashare_project,
-                                    '--query_filter', 'contentType=message/rfc822', 
+                                    '--filter_by', 'contentType=message/rfc822', 
                                     ])
         json_result = loads(result.output)
         self.assertEqual([{'count': 2, 'field': 'contentType', 'type': 'keyword'},

--- a/tests/test_metadata_fields_multi_filter.py
+++ b/tests/test_metadata_fields_multi_filter.py
@@ -1,0 +1,41 @@
+from json import loads
+
+from click.testing import CliRunner
+
+from tarentula.cli import cli
+from .test_abstract import TestAbstract
+
+
+def load_json_file(path):
+    return loads(open(path).read())
+
+
+class TestMultiFilter(TestAbstract):
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_zero_results(self):
+        with self.existing_species_documents():
+            runner = CliRunner()
+            result = runner.invoke(cli, ['list-metadata', 
+                                        '--elasticsearch-url', self.elasticsearch_url, 
+                                        '--datashare-project', self.datashare_project,
+                                        '--filter_by', 'type=Document,contentType=message/abc', 
+                                        ])
+            json_result = loads(result.output)
+            self.assertEqual([], json_result)
+
+    def test_some_results(self):
+        with self.existing_species_documents():
+            runner = CliRunner()
+            result = runner.invoke(cli, ['list-metadata', 
+                                        '--elasticsearch-url', self.elasticsearch_url, 
+                                        '--datashare-project', self.datashare_project,
+                                        '--filter_by', 'type=Document,contentType=image/png', 
+                                        ])
+            json_result = loads(result.output)
+            self.assertEqual([{'count': 1, 'field': 'contentType', 'type': 'keyword'},
+                            {"count": 1, "field": "extractionDate", "type": "date"},
+                            {'count': 1, 'field': 'name', 'type': 'text'},
+                            {'count': 1, 'field': 'type', 'type': 'keyword'}], json_result)


### PR DESCRIPTION
The goal of the PR is to add support for limiting the number of document returned by datashare/elasticsearch.

It is limited for now to : 
- passing a parameter `skip` (int) to the commands `download` and `export-by-query`
- this parameter is not taken if there is a scroll (a warning log is issued)

Some notes about this: 

## Names

- the name "size" has been discussed and we agreed that it could be misleading to limit the number of results with this parameter that is related to the window size (thus it could make the user think that it would only affect the size of the search results returned and not the total). That is one of the reason for which it has not been added (keeping the size parameter for pages/scroll)
- the name `skip` is used for the parameter `from` of ES.  If want to _build up a common, rigorous language between developers and users_ as known as [ubiquitous language](https://www.martinfowler.com/bliki/UbiquitousLanguage.html) then we could call it from also (and find workaround for the python reserved word)
- it could also be taken "as is" to just ignore first results (and the implementation would be different)

## Duplication

There are pieces of code that are exactly the same between `download.py` and `export_by_query.py` so we should refactor :
- we could extract a common class and make them heritate from it 
- or we could do it by delegation with a common object shared by both classes (it lowers coupling)

What do you think about the names issue?
What do you think of the strategy to adopt with the duplication removal?
Do we continue on this PR or do we create another one?