### PR TITLE
fix: `DatashareClient.count` with multiple fields query

### DIFF
--- a/tarentula/datashare_client.py
+++ b/tarentula/datashare_client.py
@@ -186,6 +186,7 @@ class DatashareClient:
 
     def count(self, index=DATASHARE_DEFAULT_PROJECT, query=None):
         if query is None: query = {}
+        query = {'query': query['query']}
         url = urljoin(self.elasticsearch_host, index, '_count')
         return requests.post(url, json=query,
                              cookies=self.cookies,

--- a/tests/test_datashare_client.py
+++ b/tests/test_datashare_client.py
@@ -124,3 +124,12 @@ class TestDatashareClient(TestAbstract):
             for document in self.datashare_client.scan_all(index=project, q='name:*', size=2):
                 count = count + 1
             self.assertEqual(count, 7)
+
+    def test_count_with_multiple_fields_query(self):
+        with self.datashare_client.temporary_project(self.datashare_project) as project:
+            query = {'query': {'bool': {'must': [{'term': {'contentType': 'application/pdf'}}]}}, 'runtime_mappings': {}}
+            try:
+                self.datashare_client.count(index=project, query=query)
+            except Exception as e:
+                msg = f"Error when counting with a complex query: {e}: {e.__traceback__}"
+                self.fail(msg)


### PR DESCRIPTION
# Fixed
- a bug where the `DatashareClient.count` was failing when called during download or export because the actual download/export query can contain multiple fields while the ES count only allows the `"query"`  one